### PR TITLE
Fix: UCSHandle expects login then password.

### DIFF
--- a/library/ucs.py
+++ b/library/ucs.py
@@ -5,7 +5,7 @@ from ucsmsdk.ucshandle import UcsHandle
 
 class UCS(object):
     def __init__(self, ucsm_ip="", ucsm_login="", ucsm_pw=""):
-        self.handle = UcsHandle(ucsm_ip, ucsm_pw ,ucsm_login)
+        self.handle = UcsHandle(ucsm_ip, ucsm_login ,ucsm_pw)
         self.ucsm_ip = ucsm_ip
         self.ucsm_pw = ucsm_pw
         self.ucsm_login = ucsm_login


### PR DESCRIPTION
Seems that your library is calling parameters in the wrong order. I kept getting authentication failures. After making this change I was able to get them talking.